### PR TITLE
Change map grid to 3-column layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -55,7 +55,7 @@ body {
 
 .map-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  grid-template-columns: repeat(3, 1fr);
   gap: 15px;
   margin-bottom: 20px;
 }
@@ -299,7 +299,7 @@ body {
   }
   
   .map-grid {
-      grid-template-columns: repeat(2, 1fr);
+      grid-template-columns: repeat(3, 1fr);
       gap: 10px;
   }
   
@@ -347,7 +347,7 @@ body {
   }
   
   .map-grid {
-      grid-template-columns: 1fr;
+      grid-template-columns: repeat(3, 1fr);
   }
   
   .npc-info {


### PR DESCRIPTION
## Summary
- adjust `.map-grid` in `style.css` to show the village options in three columns

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a12cf8f08833083fe2eb0b6c0d8e8