### PR TITLE
Add speech synthesis for spell selection

### DIFF
--- a/script.js
+++ b/script.js
@@ -414,9 +414,20 @@ function createSpellButtons() {
     });
 }
 
+// 🔊 魔法名を読み上げる
+function speakSpell(spellName) {
+    if ('speechSynthesis' in window) {
+        const utterance = new SpeechSynthesisUtterance(`${spellName}！`);
+        utterance.lang = 'ja-JP';
+        window.speechSynthesis.cancel();
+        window.speechSynthesis.speak(utterance);
+    }
+}
+
 // ✨ 魔法を唱える
 function castSpell(spellName) {
     console.log(`✨ 魔法「${spellName}」を使用`);
+    speakSpell(spellName);
     
     if (!currentEvent) {
         console.error('❌ 現在のイベントがありません');


### PR DESCRIPTION
## Summary
- Speak the chosen spell aloud using Web Speech API
- Call the new speech function whenever a spell is cast

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b30ca37dc8330b3962c2e8d72956b