### PR TITLE
Use Twemoji to render emoji as SVG images

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,6 +115,7 @@
         </footer>
     </div>
 
+    <script src="https://twemoji.maxcdn.com/v/latest/twemoji.min.js" crossorigin="anonymous"></script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -569,3 +569,22 @@ function chooseEnding(choice) {
 
 console.log('🎮 魔王を倒した勇者の魔法RPG - 準備完了！');
 console.log('💡 デバッグコマンド: debugGame(), resetGame(), getGameProgress()');
+
+// 🖼️ すべての絵文字をSVG画像に変換
+const applyTwemoji = () => {
+    if (window.twemoji) {
+        twemoji.parse(document.body, { folder: 'svg', ext: '.svg' });
+    }
+};
+
+applyTwemoji();
+
+const twemojiObserver = new MutationObserver(() => {
+    applyTwemoji();
+});
+
+twemojiObserver.observe(document.body, {
+    childList: true,
+    subtree: true,
+    characterData: true
+});

--- a/style.css
+++ b/style.css
@@ -6,10 +6,17 @@
 }
 
 body {
-  font-family: 'Arial', sans-serif;
-  background: linear-gradient(135deg, #87CEEB 0%, #98FB98 100%);
-  min-height: 100vh;
-  padding: 10px;
+    font-family: 'Arial', sans-serif;
+    background: linear-gradient(135deg, #87CEEB 0%, #98FB98 100%);
+    min-height: 100vh;
+    padding: 10px;
+}
+
+img.emoji {
+  height: 1em;
+  width: 1em;
+  margin: 0 .05em 0 .1em;
+  vertical-align: -0.1em;
 }
 
 .game-container {


### PR DESCRIPTION
## Summary
- add Twemoji CDN script to convert emoji to SVG icons
- parse emoji on DOM changes and style emoji images

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d67644cc88330968dbf7b60051754