### PR TITLE
Enhance icon sizes for map and spells

### DIFF
--- a/script.js
+++ b/script.js
@@ -432,7 +432,7 @@ function createSpellButtons() {
     spells.forEach(spell => {
         const button = document.createElement('button');
         button.className = 'spell-button';
-        button.innerHTML = `${spell.icon}<br>${spell.name}`;
+        button.innerHTML = `<span class="spell-icon">${spell.icon}</span><br>${spell.name}`;
         button.title = spell.effect; // ツールチップで効果を表示
         
         // クリック時の処理

--- a/style.css
+++ b/style.css
@@ -87,13 +87,13 @@ img.emoji {
 }
 
 .area-icon {
-  font-size: 2.5rem;
+  font-size: 3.75rem;
   margin-bottom: 10px;
 }
 
 .forest-image {
-  width: 2.5rem;
-  height: 2.5rem;
+  width: 3.75rem;
+  height: 3.75rem;
   object-fit: cover;
   border-radius: 4px;
 }
@@ -221,6 +221,10 @@ img.emoji {
 
 .spell-button:active {
   transform: translateY(0);
+}
+
+.spell-icon {
+  font-size: 1.5em;
 }
 
 /* 結果画面 */
@@ -353,9 +357,14 @@ img.emoji {
   }
   
   .area-icon {
-      font-size: 2rem;
+      font-size: 3rem;
   }
-  
+
+  .forest-image {
+      width: 3rem;
+      height: 3rem;
+  }
+
   .area-name {
       font-size: 1rem;
   }


### PR DESCRIPTION
## Summary
- Enlarge village map icons and forest image by 150% for better visibility
- Add dedicated `.spell-icon` class and apply to magic buttons
- Adjust responsive styles so larger icons scale on mobile

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688eb5c449548330b520840a49ecfcc8