### PR TITLE
Increase spell chanting volume

### DIFF
--- a/script.js
+++ b/script.js
@@ -449,7 +449,7 @@ function speakSpell(spellName) {
     if ('speechSynthesis' in window) {
         const utterance = new SpeechSynthesisUtterance(`${spellName}！`);
         utterance.lang = 'ja-JP';
-        utterance.volume = 1; // 音量を最大に設定
+        utterance.volume = 1.3; // 音量を130%に設定
         window.speechSynthesis.cancel();
         window.speechSynthesis.speak(utterance);
     }


### PR DESCRIPTION
## Summary
- increase speech synthesis volume to 130% when casting spells

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68906802be188330aab4b14320f56ea3