### PR TITLE
Add looping background music

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,12 +110,14 @@
             </div>
         </main>
 
-        <footer class="game-footer">
-            <p>💫 魔王を倒した勇者が魔法で村人を助けよう！</p>
-        </footer>
-    </div>
+  <footer class="game-footer">
+      <p>💫 魔王を倒した勇者が魔法で村人を助けよう！</p>
+  </footer>
+</div>
+
+    <audio id="bgm" src="audio/mati.mp3" loop hidden></audio>
 
     <script src="https://twemoji.maxcdn.com/v/latest/twemoji.min.js" crossorigin="anonymous"></script>
     <script src="script.js"></script>
-</body>
-</html>
+  </body>
+  </html>

--- a/script.js
+++ b/script.js
@@ -612,3 +612,11 @@ twemojiObserver.observe(document.body, {
     subtree: true,
     characterData: true
 });
+
+// 🎵 BGMを再生
+const bgm = document.getElementById('bgm');
+const playBgm = () => {
+    bgm.play().catch(() => {});
+};
+playBgm();
+document.addEventListener('click', playBgm, { once: true });


### PR DESCRIPTION
## Summary
- embed hidden audio element for background music
- start playing `audio/mati.mp3` automatically with click fallback

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68907b0589148330b629959519a0ab33